### PR TITLE
Update api endpoint url

### DIFF
--- a/app.js
+++ b/app.js
@@ -714,7 +714,7 @@ async function createSettings() {
     await getMinTradingSize();
     var minOrderSizes = JSON.parse(fs.readFileSync('min_order_sizes.json'));
     //get info from https://api.liquidation.report/public/research
-    const url = "https://api.liquidation.report/public/research";
+    const url = "https://liquidation.report/api/lickhunter";
     fetch(url)
     .then(res => res.json())
     .then((out) => {
@@ -805,7 +805,7 @@ async function updateSettings() {
             }
             var minOrderSizes = JSON.parse(fs.readFileSync('min_order_sizes.json'));
             var settingsFile = JSON.parse(fs.readFileSync('settings.json'));
-            const url = "https://api.liquidation.report/public/research";
+            const url = "https://liquidation.report/api/lickhunter";
             fetch(url)
             .then(res => res.json())
             .then((out) => {


### PR DESCRIPTION
Moving foward the bot should use this new endpoint and don't want to mix it with frontend api endpoint. Since the data structure is same, there is no need for code modification.